### PR TITLE
Fix for specific large ID values tricking crc compare function

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ Dcdr.prototype.withinPercentile = function(feature, id, val) {
   var uid = this.crc(feature + id.toString());
   var percent = val * 100.00;
 
-  return uid % 100 <= percent;
+  return uid % 100 < percent;
 };
 
 Dcdr.prototype.crc = function(feature) {

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,8 @@ var mockFeatures = {
       default: {
         boolean_feature: true,
         boolean_feature_off : false,
-        percentile_feature : 0.5
+        percentile_feature : 0.5,
+        percentile_feature_off : 0
       }
     }
   }
@@ -52,6 +53,27 @@ describe('Dcdr', function() {
     expect(dcdr.isAvailableForId('percentile_feature', 2)).to.be.true;
     expect(dcdr.isAvailableForId('percentile_feature', 8)).to.be.false;
     expect(dcdr.isAvailableForId('nonexistent_feature', 6)).to.be.false;
+    done();
+  });
+
+  /**
+   * A test to guard against the crc function hashing specific values which
+   * ultimatley end in `00`, and therefore would return true for `isAvailableForId`
+   * lookups since the comparison operator was mistakenly set to `<=` versus `<`
+   */
+  it('handles percentiles with specific hashes that trick the crc % function', function(done) {
+    dcdr.setFeatures(mockFeatures);
+    expect(dcdr.isAvailableForId('percentile_feature_off', 231917551091711)).to.be.false;
+    expect(dcdr.isAvailableForId('percentile_feature_off', 3945464305025023)).to.be.false;
+    expect(dcdr.isAvailableForId('percentile_feature_off', 3945464305025023)).to.be.false;
+    expect(dcdr.isAvailableForId('percentile_feature_off', 669979974303743)).to.be.false;
+    expect(dcdr.isAvailableForId('percentile_feature_off', 7717664547930111)).to.be.false;
+    done();
+  });
+
+  it('handles percentiles with really large ID values', function(done) {
+    dcdr.setFeatures(mockFeatures);
+    expect(dcdr.isAvailableForId('percentile_feature_off', Number.MAX_SAFE_INTEGER)).to.be.false;
     done();
   });
 


### PR DESCRIPTION
When using large ID values (Random 0 - Number.MAX_SAFE_INTEGER) in an attempt to limit a % of requests to a given feature flag, certain values mistakenly return `true` when the decider value is set to a value expecting to be `false`.

An incorrect comparison was used when ported from the parent: [dcdr (for go)](https://github.com/vsco/dcdr/blob/master/client/client.go#L238)

Comparison Operator: [index.js#L50](https://github.com/vsco/dcdr-js/blob/cc41f8638bf87bff4ff5686c5ae6281b4e3a29a8/index.js#L50)
```
Dcdr.prototype.withinPercentile = function(feature, id, val) {
  var uid = this.crc(feature + id.toString());
  var percent = val * 100.00;

  return uid % 100 <= percent;
};
```


Example feature map:
```
{
  dcdr: {
    features: {
      default: {
        percentile_feature_off : 0
      }
    }
  }
};
```

Example Failure (due to presence of `<=` versus `<`:
```
console.log(this.crc('percentile_feature_off', 231917551091711))
> 951765300

console.log(dcdr.isAvailableForId('percentile_feature_off', 231917551091711));
> true
```