### PR TITLE
Fixes crash on reading empty config file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ Dcdr.prototype.init = function(config) {
 
   fs.exists(this.config.dcdr.path, function(exists) {
     if (exists) {
-      this.loadFeatures(this.config.dcdr.path);
+      this.loadFeatures(true, this.config.dcdr.path);
       this.watchConfig();
     } else {
       this.config.logger.error(this.config.dcdr.path + ' not found.');
@@ -26,13 +26,16 @@ Dcdr.prototype.init = function(config) {
 Dcdr.prototype.watchConfig = function() {
   fs.watch(this.config.dcdr.path, { persistent: false }, function() {
     this.config.logger.info('Reloading features from ' + this.config.dcdr.path);
-    this.loadFeatures(this.config.dcdr.path);
+    this.loadFeatures(false, this.config.dcdr.path);
   }.bind(this));
 };
 
-Dcdr.prototype.loadFeatures = function(path) {
-  var features = JSON.parse(fs.readFileSync(path, 'utf8'));
-  this.setFeatures(features);
+Dcdr.prototype.loadFeatures = function(isInitialLoad, path) {
+  var featuresJson = fs.readFileSync(path, 'utf8');
+  if (featuresJson !== '' || isInitialLoad) {
+    var features = JSON.parse(featuresJson);
+    this.setFeatures(features);
+  }
 };
 
 Dcdr.prototype.setFeatures = function(features) {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ Dcdr.prototype.init = function(config) {
 
   fs.exists(this.config.dcdr.path, function(exists) {
     if (exists) {
-      this.loadFeatures(true, this.config.dcdr.path);
+      this.loadFeatures(this.config.dcdr.path, true);
       this.watchConfig();
     } else {
       this.config.logger.error(this.config.dcdr.path + ' not found.');
@@ -26,11 +26,11 @@ Dcdr.prototype.init = function(config) {
 Dcdr.prototype.watchConfig = function() {
   fs.watch(this.config.dcdr.path, { persistent: false }, function() {
     this.config.logger.info('Reloading features from ' + this.config.dcdr.path);
-    this.loadFeatures(false, this.config.dcdr.path);
+    this.loadFeatures(this.config.dcdr.path, false);
   }.bind(this));
 };
 
-Dcdr.prototype.loadFeatures = function(isInitialLoad, path) {
+Dcdr.prototype.loadFeatures = function(path, isInitialLoad) {
   var featuresJson = fs.readFileSync(path, 'utf8');
   if (featuresJson !== '' || isInitialLoad) {
     var features = JSON.parse(featuresJson);

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 
+var fs = require('fs');
 var chai = require('chai');
 var expect = chai.expect;
 
@@ -97,5 +98,17 @@ describe('Dcdr', function() {
 
     expect(dcdr.isAvailable('boolean_feature')).to.be.false;
     done();
+  });
+
+  it('handles features file updated to zero length', function(done) {
+    var tempDir = process.env.TEMP || process.env.TMP || '/tmp';
+    var tempPath = tempDir + '/dcdr-test.json';
+
+    fs.writeFileSync(tempPath, '{"dcdr":{"features":{"default":{"test": 1}}}}');
+    dcdr.init({ dcdr: { path: tempPath } });
+    setTimeout(function() {
+      fs.writeFileSync(tempPath, '');
+      setTimeout(done, 100);
+    }, 50);
   });
 });


### PR DESCRIPTION
When writing a config file on Linux, it's a common practice to open the file with the truncate option to delete the old content, then proceed to write the new content. In that case, the file watch will receive two notifications, one for the truncation and one for the actual write. Depending on the timing, it's possible to read empty content when reacting to the first notification. In that case `JSON.parse` throws an exception. This PR attempts to handle such case by ignoring zero-length contents.