### PR TITLE
Updates eslint and mocha.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - '5'
   - '6'
   - '8'
+  - '9'
+  - '10'
 
 install:
   - script/bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
+  - '5'
   - '6'
-  - '4'
+  - '8'
 
 install:
   - script/bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 node_js:
   - '5'
   - '6'
-  - '8'
-  - '9'
   - '10'
+  - '11'
+  - '12'
 
 install:
   - script/bootstrap

--- a/index.js
+++ b/index.js
@@ -28,8 +28,16 @@ Dcdr.prototype.watchConfig = function() {
     this.loadFeatures(this.config.dcdr.path, false);
   }
 
-  chokidar.watch(this.config.dcdr.path)
+  this.watcher = chokidar.watch(this.config.dcdr.path)
     .on('change', watchHandler.bind(this));
+};
+
+// Stop the watch. Required to exxit tests gracefully.
+Dcdr.prototype.internalStopWatch = function() {
+  if (this.watcher) {
+    this.watcher.close();
+    delete this.watcher;
+  }
 };
 
 Dcdr.prototype.loadFeatures = function(path, isInitialLoad) {
@@ -56,7 +64,7 @@ Dcdr.prototype.withinPercentile = function(feature, id, val) {
 };
 
 Dcdr.prototype.crc = function(feature) {
-  var buf = new Buffer(feature);
+  var buf = Buffer.from(feature);
   return crc.unsigned(buf);
 };
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "buffer-crc32": "^0.2.5",
-    "chokidar": "^2.0.4"
+    "chokidar": "^2.1.6"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^4.18.2",
-    "mocha": "^3.0.2"
+    "eslint": "^5.16.0",
+    "mocha": "^6.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcdr",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "VSCO's DCDR (Decider) package for Node.js",
   "license": "MIT",
   "repository": {
@@ -9,7 +9,7 @@
   },
   "author": "VSCO Eng <eng@vsco.co> (http://vsco.co)",
   "engines": {
-    "node": ">=4"
+    "node": ">=5.10"
   },
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,10 @@ describe('Dcdr', function() {
   var tempDir = process.env.TEMP || process.env.TMP || '/tmp';
   var tempPath = tempDir + '/dcdr-test.json';
 
+  afterEach(function() {
+    dcdr.internalStopWatch();
+  });
+
   // deletes test decider.json file after tests are complete
   after(function() {
     fs.unlinkSync(tempPath);


### PR DESCRIPTION
`npm audit` discovered security vulnerability in `eslint` and dependencies of `mocha`, so I updated these projects. `mocha` 4.x no longer forces exit after tests complete, so updating past 3.x necessitated changes in the tests to shut down the watches.